### PR TITLE
feat(l1, l2): add notification levels

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -669,6 +669,7 @@ impl EthrexReplayCommand {
                     cache_dir: PathBuf::from("./replay_cache"),
                     verbose: false,
                     network: None,
+                    notification_level: NotificationLevel::default(),
                 };
 
                 let report = replay_custom_l2_blocks(max(1, n_blocks), opts).await?;


### PR DESCRIPTION
**Motivation**

When passing `--slack-webhook-url`, we don't always want to send notifications always but only in specific cases.