### PR TITLE
chore(l1, l2): add tag release workflow

### DIFF
--- a/.github/workflows/pr-main.yaml
+++ b/.github/workflows/pr-main.yaml
@@ -95,11 +95,11 @@ jobs:
       matrix:
         backend: ["sp1", "risc0", "exec"]
     steps:
-      - name: Free Disk Space
-        uses: ./.github/actions/free-disk
-
       - name: Checkout sources
         uses: actions/checkout@v4
+
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk
 
       - name: Setup Rust Environment
         uses: ./.github/actions/setup-rust


### PR DESCRIPTION
**Motivation**

We want to be able to release ethrex-compatible ethrex-replay versions similar to how we do with ethrex, with a few more binary combinations:

| Name | L2 | SP1 | RISC0 | CUDA |
| --- | --- | --- | --- | --- |
| ethrex-replay-linux-x86-64 | ❌ | ✅ | ✅ | ❌ |
| ethrex-replay-linux-aarch64 | ❌ | ✅ | ✅ | ❌ |
| ethrex-replay-macos-aarch64 | ❌ | ✅ | ✅ | ❌ |
| ethrex-replay-l2-linux-x86-64 | ✅ | ✅ | ✅ | ❌ |
| ethrex-replay-l2-linux-aarch64 | ✅ | ✅ | ✅ | ❌ |
| ethrex-replay-l2-macos-aarch64 | ✅ | ✅ | ✅ | ❌ |
| ethrex-replay-linux-x86-64-gpu | ❌ | ✅ | ✅ | ✅ |
| ethrex-replay-linux-aarch64-gpu | ❌ | ✅ | ✅ | ✅ |
| ethrex-replay-macos-aarch64-gpu | ❌ | ✅ | ✅ | ✅ |
| ethrex-replay-l2-linux-x86-64-gpu | ✅ | ✅ | ✅ | ✅ |
| ethrex-replay-l2-linux-aarch64-gpu | ✅ | ✅ | ✅ | ✅ |