### PR TITLE
ci(l1): add explicit least-privilege permissions to workflow files

### DIFF
--- a/.github/workflows/pr-lint-gha.yaml
+++ b/.github/workflows/pr-lint-gha.yaml
@@ -6,6 +6,9 @@ on:
       - ".github/**.yaml"
       - ".github/*.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/pr-lint-pr-title.yaml
+++ b/.github/workflows/pr-lint-pr-title.yaml
@@ -7,6 +7,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds explicit `permissions:` blocks to all workflow files to restrict `GITHUB_TOKEN` to least-privilege
- `pr-lint-gha.yaml` → `contents: read` (checkout + actionlint)
- `pr-lint-pr-title.yaml` → `pull-requests: read` (only reads PR metadata, no checkout)

## Related code scanning alerts

- `pr-lint-gha.yaml` — [#1](https://github.com/lambdaclass/ethrex-replay/security/code-scanning/1)
- `pr-lint-pr-title.yaml` — [#2](https://github.com/lambdaclass/ethrex-replay/security/code-scanning/2)