### PR TITLE
refactor(l1): remove keys dependency, pin ethrex deps, and add NativeCrypto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "bls12_381"
 version = "0.8.0"
-source = "git+https://github.com/lambdaclass/bls12_381?branch=expose-fp-struct#219174187bd78154cec35b0809799fc2c991a579"
+source = "git+https://github.com/lambdaclass/bls12_381?branch=expose-affine-constructors#78cad0378b17fc3157b83f514be192bf46edf9a1"
 dependencies = [
  "digest 0.10.7",
  "ff 0.13.1",
@@ -3697,7 +3697,7 @@ dependencies = [
 [[package]]
 name = "ethrex-blockchain"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bytes",
  "ethrex-common",
@@ -3718,7 +3718,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3751,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "ethrex-config"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "ethrex-common",
  "ethrex-p2p",
@@ -3763,10 +3763,22 @@ dependencies = [
 [[package]]
 name = "ethrex-crypto"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "bls12_381 0.8.0",
  "c-kzg",
+ "ethereum-types 0.15.1",
+ "ff 0.13.1",
+ "hex-literal",
  "kzg-rs",
+ "malachite 0.6.1",
+ "p256",
+ "ripemd",
+ "secp256k1",
+ "sha2",
  "thiserror 2.0.18",
  "tiny-keccak",
 ]
@@ -3774,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "ethrex-dev"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bytes",
  "envy",
@@ -3794,28 +3806,32 @@ dependencies = [
 [[package]]
 name = "ethrex-guest-program"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bytes",
+ "ethereum-types 0.15.1",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-rlp",
  "ethrex-vm",
  "hex",
+ "k256",
  "risc0-build",
  "rkyv",
  "serde",
  "serde_with",
  "sp1-build",
  "sp1-sdk",
+ "substrate-bn",
  "thiserror 2.0.18",
+ "ziskos",
 ]
 
 [[package]]
 name = "ethrex-l2"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -3874,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-common"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -3898,13 +3914,14 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-rpc"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "axum 0.8.8",
  "bytes",
  "ethereum-types 0.15.1",
  "ethrex-blockchain",
  "ethrex-common",
+ "ethrex-crypto",
  "ethrex-l2-common",
  "ethrex-p2p",
  "ethrex-rlp",
@@ -3928,43 +3945,31 @@ dependencies = [
 [[package]]
 name = "ethrex-levm"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
  "bitvec",
- "bls12_381 0.8.0",
  "bytes",
  "datatest-stable",
  "derive_more 1.0.0",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-rlp",
- "k256",
- "lambdaworks-math 0.13.0",
  "lazy_static",
  "malachite 0.6.1",
- "p256",
  "rayon",
- "ripemd",
  "rustc-hash 2.1.1",
- "secp256k1",
  "serde",
  "serde_json",
- "sha2",
  "sha3",
  "strum 0.27.2",
- "substrate-bn",
  "thiserror 2.0.18",
  "walkdir",
- "ziskos",
 ]
 
 [[package]]
 name = "ethrex-metrics"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "axum 0.8.8",
  "ethrex-common",
@@ -3980,7 +3985,7 @@ dependencies = [
 [[package]]
 name = "ethrex-monitor"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bytes",
  "chrono",
@@ -4013,7 +4018,7 @@ dependencies = [
 [[package]]
 name = "ethrex-p2p"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4058,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "ethrex-prover"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4105,6 +4110,7 @@ dependencies = [
  "ethrex-blockchain",
  "ethrex-common",
  "ethrex-config",
+ "ethrex-crypto",
  "ethrex-guest-program",
  "ethrex-l2",
  "ethrex-l2-common",
@@ -4139,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rlp"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4153,7 +4159,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rpc"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -4192,7 +4198,7 @@ dependencies = [
 [[package]]
 name = "ethrex-sdk"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4218,7 +4224,7 @@ dependencies = [
 [[package]]
 name = "ethrex-sdk-contract-utils"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -4227,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "ethrex-storage"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4252,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "ethrex-storage-rollup"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4272,7 +4278,7 @@ dependencies = [
 [[package]]
 name = "ethrex-trie"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4296,7 +4302,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=main#9d368382b52098cdc09c96cb8901bdb60ed00208"
+source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -6072,7 +6078,6 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "rand 0.8.5",
- "rayon",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "sp1-sdk",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -214,12 +214,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f374d3c6d729268bbe2d0e0ff992bb97898b2df756691a62ee1d5f0506bc39"
+checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
 dependencies = [
  "alloy-primitives",
- "num_enum 0.7.5",
+ "num_enum 0.7.6",
  "strum 0.27.2",
 ]
 
@@ -800,13 +800,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec",
  "derive_more 2.1.1",
  "nybbles",
  "serde",
@@ -847,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -862,15 +861,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -1274,9 +1273,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "as_derive_utils"
@@ -1857,9 +1853,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d13a61f2963b88eef9c1be03df65d42f6996dfeac1054870d950fcf66686f83"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -1867,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d314cc62af2b6b0c65780555abb4d02a03dd3b799cd42419044f0c38d99738c0"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
  "darling 0.23.0",
  "ident_case",
@@ -1994,9 +1990,9 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "c-kzg"
-version = "2.1.6"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "blst",
  "cc",
@@ -2089,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2207,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2217,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2229,9 +2225,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2241,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -2289,9 +2285,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -3697,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "ethrex-blockchain"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bytes",
  "ethrex-common",
@@ -3718,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -3751,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "ethrex-config"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "ethrex-common",
  "ethrex-p2p",
@@ -3763,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "ethrex-crypto"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3786,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "ethrex-dev"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bytes",
  "envy",
@@ -3806,7 +3802,7 @@ dependencies = [
 [[package]]
 name = "ethrex-guest-program"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -3831,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "agg_mode_sdk",
  "alloy",
@@ -3890,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-common"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -3914,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-rpc"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "axum 0.8.8",
  "bytes",
@@ -3938,14 +3934,14 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
 [[package]]
 name = "ethrex-levm"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bitvec",
  "bytes",
@@ -3969,23 +3965,23 @@ dependencies = [
 [[package]]
 name = "ethrex-metrics"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "axum 0.8.8",
  "ethrex-common",
- "prometheus 0.13.4",
+ "prometheus",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
 name = "ethrex-monitor"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bytes",
  "chrono",
@@ -4018,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "ethrex-p2p"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4042,7 +4038,7 @@ dependencies = [
  "hmac",
  "indexmap 2.13.0",
  "lazy_static",
- "prometheus 0.14.0",
+ "prometheus",
  "rand 0.8.5",
  "rayon",
  "rustc-hash 2.1.1",
@@ -4063,7 +4059,7 @@ dependencies = [
 [[package]]
 name = "ethrex-prover"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4095,7 +4091,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
@@ -4139,13 +4135,13 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
 name = "ethrex-rlp"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4159,7 +4155,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rpc"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "axum 0.8.8",
  "axum-extra",
@@ -4191,14 +4187,14 @@ dependencies = [
  "tokio-util",
  "tower-http",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "uuid 1.22.0",
 ]
 
 [[package]]
 name = "ethrex-sdk"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bytes",
  "ethereum-types 0.15.1",
@@ -4224,7 +4220,7 @@ dependencies = [
 [[package]]
 name = "ethrex-sdk-contract-utils"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -4233,7 +4229,7 @@ dependencies = [
 [[package]]
 name = "ethrex-storage"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4258,7 +4254,7 @@ dependencies = [
 [[package]]
 name = "ethrex-storage-rollup"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4278,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "ethrex-trie"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4302,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "9.0.0"
-source = "git+https://github.com/lambdaclass/ethrex?branch=refactor%2Fremove-keys-from-execution-witness#adf071156c1ea969f756ace903ee1f09e4c2fbd9"
+source = "git+https://github.com/lambdaclass/ethrex?rev=b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6#b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6"
 dependencies = [
  "bincode 1.3.3",
  "bytes",
@@ -4729,23 +4725,23 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "gdbstub"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf845b08f7c2ef3b5ad19f80779d43ae20d278652b91bb80adda65baf2d8ed6"
+checksum = "5bafc7e33650ab9f05dcc16325f05d56b8d10393114e31a19a353b86fa60cfe7"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
  "log",
  "managed",
  "num-traits",
- "paste",
+ "pastey",
 ]
 
 [[package]]
 name = "gdbstub_arch"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dde0e1b68787036ccedd0b1ff6f953527a0e807e571fbe898975203027278f"
+checksum = "6c02bfe7bd65f42bcda751456869dfa1eb2bd1c36e309b9ec27f4888d41cf258"
 dependencies = [
  "gdbstub",
  "num-traits",
@@ -5813,9 +5809,9 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling 0.23.0",
  "indoc",
@@ -6139,9 +6135,9 @@ source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.15.0#b3ca745b80
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
@@ -6212,9 +6208,9 @@ dependencies = [
 
 [[package]]
 name = "libtest-mimic"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
 dependencies = [
  "anstream",
  "anstyle",
@@ -6224,9 +6220,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.24"
+version = "1.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
+checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
 dependencies = [
  "cc",
  "libc",
@@ -6590,7 +6586,7 @@ dependencies = [
  "once_cell",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -6974,11 +6970,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
- "num_enum_derive 0.7.5",
+ "num_enum_derive 0.7.6",
  "rustversion",
 ]
 
@@ -6996,9 +6992,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7101,9 +7097,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -7119,9 +7115,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
@@ -7151,9 +7147,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -8129,7 +8125,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-forest",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9)",
 ]
 
@@ -8167,7 +8163,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-forest",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "zkhash 0.2.0 (git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9)",
 ]
 
@@ -9407,6 +9403,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9603,9 +9605,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -9792,42 +9794,24 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
 dependencies = [
  "bitflags 2.11.0",
  "hex",
- "lazy_static",
  "procfs-core",
  "rustix 0.38.44",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
 dependencies = [
  "bitflags 2.11.0",
  "hex",
-]
-
-[[package]]
-name = "prometheus"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
-dependencies = [
- "cfg-if 1.0.4",
- "fnv",
- "lazy_static",
- "libc",
- "memchr",
- "parking_lot 0.12.5",
- "procfs",
- "protobuf 2.28.0",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -9839,9 +9823,11 @@ dependencies = [
  "cfg-if 1.0.4",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot 0.12.5",
- "protobuf 3.7.2",
+ "procfs",
+ "protobuf",
  "thiserror 2.0.18",
 ]
 
@@ -9915,12 +9901,6 @@ checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "protobuf"
@@ -10028,9 +10008,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -10914,7 +10894,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "libm",
- "num_enum 0.7.5",
+ "num_enum 0.7.6",
  "paste",
  "stability",
 ]
@@ -11324,9 +11304,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -11619,9 +11599,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -11638,11 +11618,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -12161,7 +12141,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "tracing-forest",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "typenum",
  "web-time",
 ]
@@ -12312,7 +12292,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "tracing-appender",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -12569,7 +12549,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -12866,9 +12846,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -13079,9 +13059,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -13380,7 +13360,7 @@ dependencies = [
  "crossbeam-channel 0.5.15",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -13411,7 +13391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -13424,7 +13404,7 @@ dependencies = [
  "smallvec",
  "thiserror 1.0.69",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -13449,9 +13429,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -13527,7 +13507,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "ratatui",
  "tracing",
- "tracing-subscriber 0.3.22",
+ "tracing-subscriber 0.3.23",
  "unicode-segmentation",
 ]
 
@@ -14822,18 +14802,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,23 +14,24 @@ inherits = "release"
 debug = 2
 
 [dependencies]
-ethrex-config = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-config", branch = "main" }
-ethrex-storage = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-storage", branch = "main" }
-ethrex-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-common", branch = "main" }
-ethrex-vm = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-vm", branch = "main" }
-ethrex-levm = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-levm", branch = "main" }
-ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rpc", branch = "main" }
-ethrex-p2p = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-p2p", branch = "main" }
-ethrex-trie = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-trie", branch = "main" }
-ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rlp", branch = "main" }
-ethrex-blockchain = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-blockchain", branch = "main" }
-ethrex-l2 = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2", branch = "main", optional = true }
-ethrex-l2-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-common", branch = "main" }
-ethrex-storage-rollup = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-storage-rollup", branch = "main", optional = true }
-ethrex-sdk = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-sdk", branch = "main" }
-ethrex-l2-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-rpc", branch = "main" }
-ethrex-prover = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-prover", branch = "main", default-features = false }
-ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-guest-program", branch = "main", default-features = false }
+ethrex-config = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-config", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-storage = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-storage", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-common", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-vm = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-vm", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-levm = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-levm", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rpc", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-p2p = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-p2p", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-trie = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-trie", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rlp", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-blockchain = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-blockchain", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-l2 = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2", branch = "refactor/remove-keys-from-execution-witness", optional = true }
+ethrex-l2-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-common", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-storage-rollup = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-storage-rollup", branch = "refactor/remove-keys-from-execution-witness", optional = true }
+ethrex-sdk = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-sdk", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-l2-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-rpc", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-prover = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-prover", branch = "refactor/remove-keys-from-execution-witness", default-features = false }
+ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-guest-program", branch = "refactor/remove-keys-from-execution-witness", default-features = false }
+ethrex-crypto = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-crypto", branch = "refactor/remove-keys-from-execution-witness" }
 
 serde = { version = "1.0.203", features = ["derive"] }
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,24 +14,24 @@ inherits = "release"
 debug = 2
 
 [dependencies]
-ethrex-config = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-config", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-storage = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-storage", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-common", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-vm = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-vm", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-levm = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-levm", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rpc", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-p2p = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-p2p", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-trie = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-trie", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rlp", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-blockchain = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-blockchain", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-l2 = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2", branch = "refactor/remove-keys-from-execution-witness", optional = true }
-ethrex-l2-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-common", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-storage-rollup = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-storage-rollup", branch = "refactor/remove-keys-from-execution-witness", optional = true }
-ethrex-sdk = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-sdk", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-l2-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-rpc", branch = "refactor/remove-keys-from-execution-witness" }
-ethrex-prover = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-prover", branch = "refactor/remove-keys-from-execution-witness", default-features = false }
-ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-guest-program", branch = "refactor/remove-keys-from-execution-witness", default-features = false }
-ethrex-crypto = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-crypto", branch = "refactor/remove-keys-from-execution-witness" }
+ethrex-config = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-config", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-storage = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-storage", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-common", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-vm = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-vm", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-levm = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-levm", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rpc", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-p2p = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-p2p", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-trie = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-trie", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-rlp", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-blockchain = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-blockchain", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-l2 = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6", optional = true }
+ethrex-l2-common = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-common", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-storage-rollup = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-storage-rollup", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6", optional = true }
+ethrex-sdk = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-sdk", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-l2-rpc = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-l2-rpc", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
+ethrex-prover = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-prover", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6", default-features = false }
+ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-guest-program", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6", default-features = false }
+ethrex-crypto = { git = "https://github.com/lambdaclass/ethrex", package = "ethrex-crypto", rev = "b962fbfbacb9980a0d3682c20ec2be1bc2fd33a6" }
 
 serde = { version = "1.0.203", features = ["derive"] }
 hex = "0.4.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1041,8 +1041,6 @@ async fn prepare_no_zkvm_state(cache: &Cache) -> eyre::Result<(Store, Block, Str
     // Set up all storage tries by enumerating accounts directly from the state trie.
     // Leaf entries in the committed trie have paths of length 65: 64 nibbles for
     // keccak256(address) + 1 leaf flag (0x10). Their values are RLP-encoded AccountState.
-    // This avoids relying on the `keys` field which has been removed from the
-    // ExecutionWitness spec by the Ethereum Foundation.
     let account_state_trie = InMemoryTrieDB::from_nodes(state_root, &all_nodes)?;
     let account_entries: Vec<(Vec<u8>, Vec<u8>)> = {
         let inner = account_state_trie.inner();
@@ -1072,9 +1070,6 @@ async fn prepare_no_zkvm_state(cache: &Cache) -> eyre::Result<(Store, Block, Str
         };
 
         let storage_trie_nodes = get_trie_nodes_with_dummies(storage_trie);
-        if storage_trie_nodes.is_empty() {
-            continue;
-        }
 
         // Convert first 64 nibbles back to 32-byte hashed address (skip leaf flag at index 64)
         let hashed_address_bytes: Vec<u8> = nibble_path[..64]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,7 +38,6 @@ use ethrex_prover::BackendType;
 #[cfg(not(feature = "l2"))]
 use ethrex_rpc::types::block_identifier::BlockIdentifier;
 use ethrex_rpc::{EthClient, debug::execution_witness::execution_witness_from_rpc_chain_config};
-use ethrex_storage::hash_address;
 use ethrex_storage::{EngineType, Store};
 #[cfg(feature = "l2")]
 use ethrex_storage_rollup::EngineTypeRollup;
@@ -1039,42 +1038,52 @@ async fn prepare_no_zkvm_state(cache: &Cache) -> eyre::Result<(Store, Block, Str
 
     trie.db().put_batch(state_trie_nodes)?;
 
-    // - Set up all storage tries for all addresses in the execution witness
-    let addresses: Vec<Address> = witness
-        .keys
-        .iter()
-        .filter(|k| k.len() == Address::len_bytes())
-        .map(|k| Address::from_slice(k))
-        .collect();
+    // Set up all storage tries by enumerating accounts directly from the state trie.
+    // Leaf entries in the committed trie have paths of length 65: 64 nibbles for
+    // keccak256(address) + 1 leaf flag (0x10). Their values are RLP-encoded AccountState.
+    // This avoids relying on the `keys` field which has been removed from the
+    // ExecutionWitness spec by the Ethereum Foundation.
+    let account_state_trie = InMemoryTrieDB::from_nodes(state_root, &all_nodes)?;
+    let account_entries: Vec<(Vec<u8>, Vec<u8>)> = {
+        let inner = account_state_trie.inner();
+        let guard = inner.lock().unwrap();
+        guard
+            .iter()
+            .filter(|(path, _)| path.len() == 65 && path[64] == 16)
+            .map(|(path, value)| (path.clone(), value.clone()))
+            .collect()
+    };
 
-    for address in &addresses {
-        let hashed_address = hash_address(address);
-
-        // Account state may not be in the state trie
-        let Some(account_state_rlp) = guest_program.state_trie.get(&hashed_address)? else {
+    for (nibble_path, account_state_rlp) in &account_entries {
+        let Ok(account_state) = AccountState::decode(account_state_rlp) else {
             continue;
         };
 
-        let account_state = AccountState::decode(&account_state_rlp)?;
-
-        // If code hash of account isn't present insert empty code so that if not found the execution doesn't break.
         let code_hash = account_state.code_hash;
         all_codes_hashed.entry(code_hash).or_insert(Code::default());
 
         let storage_root = account_state.storage_root;
+        if storage_root == *EMPTY_TRIE_HASH {
+            continue;
+        }
+
         let Ok(storage_trie) = InMemoryTrieDB::from_nodes(storage_root, &all_nodes) else {
             continue;
         };
 
         let storage_trie_nodes = get_trie_nodes_with_dummies(storage_trie);
-
-        // If there isn't any storage trie node we don't need to write anything
         if storage_trie_nodes.is_empty() {
             continue;
         }
 
-        let storage_trie_nodes = vec![(H256::from_slice(&hashed_address), storage_trie_nodes)];
+        // Convert first 64 nibbles back to 32-byte hashed address (skip leaf flag at index 64)
+        let hashed_address_bytes: Vec<u8> = nibble_path[..64]
+            .chunks(2)
+            .map(|pair| (pair[0] << 4) | pair[1])
+            .collect();
+        let hashed_address = H256::from_slice(&hashed_address_bytes);
 
+        let storage_trie_nodes = vec![(hashed_address, storage_trie_nodes)];
         store
             .write_storage_trie_nodes_batch(storage_trie_nodes)
             .await?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,7 @@ use crate::{
     slack::try_send_report_to_slack,
 };
 use ethrex_config::networks::{
-    HOLESKY_CHAIN_ID, HOODI_CHAIN_ID, MAINNET_CHAIN_ID, Network, PublicNetwork, SEPOLIA_CHAIN_ID,
+    HOODI_CHAIN_ID, MAINNET_CHAIN_ID, Network, PublicNetwork, SEPOLIA_CHAIN_ID,
 };
 
 pub const VERSION_STRING: &str = env!("CARGO_PKG_VERSION");
@@ -1316,7 +1316,6 @@ pub fn backend(zkvm: &Option<ZKVM>) -> eyre::Result<BackendType> {
 pub(crate) fn network_from_chain_id(chain_id: u64) -> Network {
     match chain_id {
         MAINNET_CHAIN_ID => Network::PublicNetwork(PublicNetwork::Mainnet),
-        HOLESKY_CHAIN_ID => Network::PublicNetwork(PublicNetwork::Holesky),
         HOODI_CHAIN_ID => Network::PublicNetwork(PublicNetwork::Hoodi),
         SEPOLIA_CHAIN_ID => Network::PublicNetwork(PublicNetwork::Sepolia),
         _ => {

--- a/src/rpc/db.rs
+++ b/src/rpc/db.rs
@@ -6,6 +6,7 @@ use crate::rpc::{get_account, get_block, retry};
 
 use bytes::Bytes;
 use ethrex_common::constants::EMPTY_KECCACK_HASH;
+use ethrex_crypto::NativeCrypto;
 use ethrex_common::types::block_execution_witness::RpcExecutionWitness;
 use ethrex_common::types::{AccountState, ChainConfig, Code, CodeMetadata, code_hash};
 use ethrex_common::{
@@ -112,7 +113,7 @@ impl RpcDB {
     async fn cache_accounts(&mut self, block: &Block) -> eyre::Result<()> {
         let txs = &block.body.transactions;
 
-        let callers = txs.iter().filter_map(|tx| tx.sender().ok());
+        let callers = txs.iter().filter_map(|tx| tx.sender(&NativeCrypto).ok());
         let to = txs.iter().filter_map(|tx| match tx.to() {
             TxKind::Call(to) => Some(to),
             TxKind::Create => None,
@@ -330,7 +331,7 @@ impl RpcDB {
         let mut db = GeneralizedDatabase::new(Arc::new(self.clone()));
 
         // pre-execute and get all state changes
-        let _ = LEVM::execute_block(block, &mut db, self.vm_type).map_err(Box::new)?;
+        let _ = LEVM::execute_block(block, &mut db, self.vm_type, &NativeCrypto).map_err(Box::new)?;
         let execution_updates = LEVM::get_state_transitions(&mut db).map_err(Box::new)?;
 
         info!(

--- a/src/rpc/db.rs
+++ b/src/rpc/db.rs
@@ -6,13 +6,13 @@ use crate::rpc::{get_account, get_block, retry};
 
 use bytes::Bytes;
 use ethrex_common::constants::EMPTY_KECCACK_HASH;
-use ethrex_crypto::NativeCrypto;
 use ethrex_common::types::block_execution_witness::RpcExecutionWitness;
 use ethrex_common::types::{AccountState, ChainConfig, Code, CodeMetadata, code_hash};
 use ethrex_common::{
     Address, H256, U256,
     types::{Block, TxKind},
 };
+use ethrex_crypto::NativeCrypto;
 use ethrex_levm::db::Database as LevmDatabase;
 use ethrex_levm::db::gen_db::GeneralizedDatabase;
 use ethrex_levm::errors::DatabaseError;
@@ -331,7 +331,8 @@ impl RpcDB {
         let mut db = GeneralizedDatabase::new(Arc::new(self.clone()));
 
         // pre-execute and get all state changes
-        let _ = LEVM::execute_block(block, &mut db, self.vm_type, &NativeCrypto).map_err(Box::new)?;
+        let _ =
+            LEVM::execute_block(block, &mut db, self.vm_type, &NativeCrypto).map_err(Box::new)?;
         let execution_updates = LEVM::get_state_transitions(&mut db).map_err(Box::new)?;
 
         info!(

--- a/src/run.rs
+++ b/src/run.rs
@@ -5,6 +5,7 @@ use ethrex_common::{
     H256,
     types::{AccountUpdate, Receipt, block_execution_witness::GuestProgramState},
 };
+use ethrex_crypto::NativeCrypto;
 use ethrex_guest_program::input::ProgramInput;
 use ethrex_levm::{db::gen_db::GeneralizedDatabase, vm::VMType};
 #[cfg(feature = "openvm")]
@@ -148,16 +149,16 @@ pub async fn run_tx(cache: Cache, tx_hash: H256) -> eyre::Result<(Receipt, Vec<A
     let changes = {
         let store: Arc<DynVmDatabase> = Arc::new(Box::new(wrapped_db.clone()));
         let mut db = GeneralizedDatabase::new(store.clone());
-        LEVM::prepare_block(block, &mut db, vm_type)?;
+        LEVM::prepare_block(block, &mut db, vm_type, &NativeCrypto)?;
         LEVM::get_state_transitions(&mut db)?
     };
     wrapped_db.apply_account_updates(&changes)?;
 
-    for (tx, tx_sender) in block.body.get_transactions_with_sender()? {
+    for (tx, tx_sender) in block.body.get_transactions_with_sender(&NativeCrypto)? {
         #[cfg(feature = "l2")]
-        let mut vm = Evm::new_for_l2(wrapped_db.clone(), fee_config)?;
+        let mut vm = Evm::new_for_l2(wrapped_db.clone(), fee_config, Arc::new(NativeCrypto))?;
         #[cfg(not(feature = "l2"))]
-        let mut vm = Evm::new_for_l1(wrapped_db.clone());
+        let mut vm = Evm::new_for_l1(wrapped_db.clone(), Arc::new(NativeCrypto));
         let mut cumulative_gas_spent = 0;
         let (receipt, _) = vm.execute_tx(
             tx,


### PR DESCRIPTION
**Motivation**

The `ExecutionWitness` struct in ethrex no longer includes a `keys` field (removed in [lambdaclass/ethrex#6356](https://github.com/lambdaclass/ethrex/pull/6356)). The `--no-zkvm` replay path relied on `witness.keys` to discover account addresses and set up storage tries. This PR adapts ethrex-replay to the new API and pins dependencies to the merge commit.

**Description**

1. **Remove keys dependency in `--no-zkvm` path:** Instead of iterating `witness.keys` to get addresses and then looking up each in the state trie, enumerate accounts directly from the state trie's `InMemoryTrieDB`. After `commit()`, leaf entries have paths of 65 nibbles (64 for `keccak256(address)` + 1 leaf flag `0x10`) with raw RLP-encoded `AccountState` as values. The first 64 nibbles are converted back to the 32-byte hashed address needed by the Store.

2. **Add `NativeCrypto` parameter:** The ethrex refactor made the `Crypto` provider injectable. All call sites that require it (`sender`, `execute_block`, `prepare_block`, `get_transactions_with_sender`, `new_for_l1`, `new_for_l2`) now pass `NativeCrypto`. Added `ethrex-crypto` as a direct dependency.

3. **Pin ethrex deps to a specific commit:** Dependencies now use `rev = "b962fbfb..."` (the merge commit of #6356 on main) instead of tracking a branch. This avoids unexpected breakage from upstream changes.

4. **Remove Holesky references:** `HOLESKY_CHAIN_ID` and `PublicNetwork::Holesky` were removed from ethrex at the pinned commit (replaced by Hoodi).